### PR TITLE
Improve flecs benchmark integration

### DIFF
--- a/benchmark/benchmarks/ECSBenchmark.h
+++ b/benchmark/benchmarks/ECSBenchmark.h
@@ -181,11 +181,9 @@ public:
       state.PauseTiming();
       Application app(m_options.add_more_complex_system);
       EntityManager& registry = app.getEntities();
-      std::vector<Entity> entities;
-      entities.resize(nentities);
 
       state.ResumeTiming();
-      this->m_entities_factory.createEmptyBulk(registry, entities);
+      this->m_entities_factory.createEmptyBulk(registry, nentities);
     }
     state.counters["entities"] = static_cast<double>(nentities);
   }
@@ -236,7 +234,7 @@ public:
       EntityManager& registry = app.getEntities();
       std::vector<Entity> entities;
       entities.resize(nentities);
-      if constexpr (HasBulkFeature<EntityFactory>) {
+      if constexpr (HasBulkFeatureWithOutput<EntityFactory>) {
         this->m_entities_factory.createMinimalBulk(registry, entities);
       } else {
         for (auto& entity : entities) {
@@ -254,7 +252,7 @@ public:
 
   template <class tEntityFactory = EntityFactory>
     requires(include_entity_benchmarks == ECSBenchmarkIncludeEntityBenchmarks::Yes &&
-             HasBulkDestroyFeature<tEntityFactory>)
+             HasBulkDestroyFeature<tEntityFactory> && HasBulkFeatureWithOutput<tEntityFactory>)
   void BM_DestroyEntitiesInBulk(benchmark::State& state) {
     const auto nentities = static_cast<size_t>(state.range(0));
     for (auto _ : state) {

--- a/benchmark/benchmarks/EntityBenchmark.h
+++ b/benchmark/benchmarks/EntityBenchmark.h
@@ -211,7 +211,7 @@ public:
     state.counters["entities"] = static_cast<double>(nentities);
   }
   template <class tEntityFactory = EntityFactory>
-    requires HasBulkDestroyFeature<tEntityFactory>
+    requires(HasBulkDestroyFeature<tEntityFactory> && HasBulkFeatureWithOutput<tEntityFactory>)
   void BM_DestroyEntitiesInBulk(benchmark::State& state) {
     const auto nentities = static_cast<size_t>(state.range(0));
     for (auto _ : state) {

--- a/benchmark/benchmarks/flecs-entities/FlecsEntityBenchmarkSuite.cpp
+++ b/benchmark/benchmarks/flecs-entities/FlecsEntityBenchmarkSuite.cpp
@@ -3,3 +3,14 @@
 static ecs::benchmarks::flecs::FlecsEntityBenchmarkSuite benchmark_suite;
 
 ECS_ENTITY_BENCHMARKS(benchmark_suite)
+
+
+static void BM_CreateEntitiesInBulk(benchmark::State& state) {
+  benchmark_suite.BM_CreateEntitiesInBulk(state);
+}
+BENCHMARK(BM_CreateEntitiesInBulk)->Apply(ecs::benchmarks::base::BEDefaultArguments);
+
+static void BM_CreateEmptyEntitiesInBulk(benchmark::State& state) {
+  benchmark_suite.BM_CreateEmptyEntitiesInBulk(state);
+}
+BENCHMARK(BM_CreateEmptyEntitiesInBulk)->Apply(ecs::benchmarks::base::BEDefaultArguments);

--- a/src/flecs/CMakeLists.txt
+++ b/src/flecs/CMakeLists.txt
@@ -7,9 +7,8 @@ cpmaddpackage(
   GITHUB_REPOSITORY
   SanderMertens/flecs
   OPTIONS
-  "FLECS_STATIC_LIBS ON"
-  "FLECS_SHARED_LIBS OFF"
-  "FLECS_DEVELOPER_WARNINGS OFF")
+  "FLECS_STATIC ON"
+  "FLECS_SHARED OFF")
 
 set(INCLUDE_DIR "include") # must be relative paths
 # NOTE: rename project in "ecs-benchmark-example-myecs"

--- a/src/flecs/flecs/FlecsApplication.h
+++ b/src/flecs/flecs/FlecsApplication.h
@@ -36,15 +36,17 @@ public:
     m_world
         .system<ecs::benchmarks::base::components::PositionComponent,
                 const ecs::benchmarks::base::components::VelocityComponent>()
-        .each(systems::MovementSystem::update);
-    m_world.system<ecs::benchmarks::base::components::DataComponent>().each(systems::DataSystem::update);
+        .iter(systems::MovementSystem::update);
+    m_world.system<ecs::benchmarks::base::components::DataComponent>()
+        .iter(systems::DataSystem::update);
     if (m_add_more_complex_system) {
       m_world
-          .system<ecs::benchmarks::base::components::PositionComponent,
+          .system<const ecs::benchmarks::base::components::PositionComponent,
                   ecs::benchmarks::base::components::VelocityComponent,
-                  ecs::benchmarks::base::components::DataComponent>()
+                  const ecs::benchmarks::base::components::DataComponent>()
           .each(systems::MoreComplexSystem::update);
-      m_world.system<ecs::benchmarks::base::components::HealthComponent>().each(systems::HealthSystem::update);
+      m_world.system<ecs::benchmarks::base::components::HealthComponent>()
+          .each(systems::HealthSystem::update);
       m_world
           .system<ecs::benchmarks::base::components::HealthComponent,
                   const ecs::benchmarks::base::components::DamageComponent>()

--- a/src/flecs/flecs/custom_flecs.h
+++ b/src/flecs/flecs/custom_flecs.h
@@ -2,13 +2,10 @@
 #define ECS_BENCHMARK_FLECS_H
 
 #define FLECS_CUSTOM_BUILD // Don't build all addons
-#define FLECS_SYSTEM
 #define FLECS_CPP
 #define FLECS_MODULE
+#define FLECS_SYSTEM
 #define FLECS_PIPELINE
-#define FLECS_TIMER
-#define FLECS_EXPR
-#define FLECS_APP
 
 #include <flecs.h>
 

--- a/src/flecs/flecs/entities/EntityFactory.cpp
+++ b/src/flecs/flecs/entities/EntityFactory.cpp
@@ -1,9 +1,53 @@
 #include "EntityFactory.h"
+
+#include <gsl/gsl-lite.hpp>
+
 #include "base/components/DataComponent.h"
 #include "base/components/PositionComponent.h"
 #include "base/components/VelocityComponent.h"
 
 namespace ecs::benchmarks::flecs::entities {
+
+EntityFactory::Entity EntityFactory::createEmpty(EntityManager& entities) {
+  return entities.entity();
+}
+
+void EntityFactory::createEmptyBulk(EntityManager& registry, size_t nentities) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(nentities);
+  ecs_bulk_init(registry, &desc);
+}
+
+/*void EntityFactory::createEmptyBulk(EntityManager& registry, std::vector<Entity>& out) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(out.size());
+  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
+  for (size_t i = 0; i < out.size(); ++i) {
+    out[i] = Entity{registry, entities[i]};
+  }
+}*/
+
+EntityFactory::Entity EntityFactory::createSingle(EntityManager& entities) {
+  return entities.entity()
+      .add<ecs::benchmarks::base::components::PositionComponent>();
+}
+
+void EntityFactory::createSingleBulk(EntityManager& registry, size_t nentities) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(nentities);
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  ecs_bulk_init(registry, &desc);
+}
+
+/*void EntityFactory::createSingleBulk(EntityManager& registry, std::vector<Entity>& out) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(out.size());
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
+  for (size_t i = 0; i < out.size(); ++i) {
+    out[i] = Entity{registry, entities[i]};
+  }
+}*/
 
 EntityFactory::Entity EntityFactory::create(EntityManager& entities) {
   return entities.entity()
@@ -12,9 +56,26 @@ EntityFactory::Entity EntityFactory::create(EntityManager& entities) {
       .add<ecs::benchmarks::base::components::DataComponent>();
 }
 
-EntityFactory::Entity EntityFactory::createSingle(EntityManager& entities) {
-  return entities.entity().add<ecs::benchmarks::base::components::PositionComponent>();
+void EntityFactory::createBulk(EntityManager& registry, size_t nentities) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(nentities);
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
+  desc.ids[2] = registry.id<ecs::benchmarks::base::components::DataComponent>();
+  ecs_bulk_init(registry, &desc);
 }
+
+/*void EntityFactory::createBulk(EntityManager& registry, std::vector<Entity>& out) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(out.size());
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
+  desc.ids[2] = registry.id<ecs::benchmarks::base::components::DataComponent>();
+  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
+  for (size_t i = 0; i < out.size(); ++i) {
+    out[i] = Entity{registry, entities[i]};
+  }
+}*/
 
 EntityFactory::Entity EntityFactory::createMinimal(EntityManager& entities) {
   return entities.entity()
@@ -22,11 +83,32 @@ EntityFactory::Entity EntityFactory::createMinimal(EntityManager& entities) {
       .add<ecs::benchmarks::base::components::VelocityComponent>();
 }
 
-EntityFactory::Entity EntityFactory::createEmpty(EntityManager& entities) {
-  return entities.entity();
+void EntityFactory::createMinimalBulk(EntityManager& registry, size_t nentities) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(nentities);
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
+  ecs_bulk_init(registry, &desc);
 }
+
+/*void EntityFactory::createMinimalBulk(EntityManager& registry, std::vector<Entity>& out) {
+  ecs_bulk_desc_t desc{0};
+  desc.count = gsl::narrow_cast<int32_t>(out.size());
+  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
+  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
+  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
+  for (size_t i = 0; i < out.size(); ++i) {
+    out[i] = Entity{registry, entities[i]};
+  }
+}*/
 
 void EntityFactory::destroy(EntityManager& /*entities*/, Entity entity) {
   entity.destruct();
+}
+
+void EntityFactory::destroyBulk(EntityManager& /*registry*/, std::vector<Entity>& entities) {
+  for (auto& entity : entities) {
+    entity.destruct();
+  }
 }
 } // namespace ecs::benchmarks::flecs::entities

--- a/src/flecs/flecs/entities/EntityFactory.cpp
+++ b/src/flecs/flecs/entities/EntityFactory.cpp
@@ -18,15 +18,6 @@ void EntityFactory::createEmptyBulk(EntityManager& registry, size_t nentities) {
   ecs_bulk_init(registry, &desc);
 }
 
-/*void EntityFactory::createEmptyBulk(EntityManager& registry, std::vector<Entity>& out) {
-  ecs_bulk_desc_t desc{0};
-  desc.count = gsl::narrow_cast<int32_t>(out.size());
-  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
-  for (size_t i = 0; i < out.size(); ++i) {
-    out[i] = Entity{registry, entities[i]};
-  }
-}*/
-
 EntityFactory::Entity EntityFactory::createSingle(EntityManager& entities) {
   return entities.entity()
       .add<ecs::benchmarks::base::components::PositionComponent>();
@@ -38,16 +29,6 @@ void EntityFactory::createSingleBulk(EntityManager& registry, size_t nentities) 
   desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
   ecs_bulk_init(registry, &desc);
 }
-
-/*void EntityFactory::createSingleBulk(EntityManager& registry, std::vector<Entity>& out) {
-  ecs_bulk_desc_t desc{0};
-  desc.count = gsl::narrow_cast<int32_t>(out.size());
-  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
-  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
-  for (size_t i = 0; i < out.size(); ++i) {
-    out[i] = Entity{registry, entities[i]};
-  }
-}*/
 
 EntityFactory::Entity EntityFactory::create(EntityManager& entities) {
   return entities.entity()
@@ -65,18 +46,6 @@ void EntityFactory::createBulk(EntityManager& registry, size_t nentities) {
   ecs_bulk_init(registry, &desc);
 }
 
-/*void EntityFactory::createBulk(EntityManager& registry, std::vector<Entity>& out) {
-  ecs_bulk_desc_t desc{0};
-  desc.count = gsl::narrow_cast<int32_t>(out.size());
-  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
-  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
-  desc.ids[2] = registry.id<ecs::benchmarks::base::components::DataComponent>();
-  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
-  for (size_t i = 0; i < out.size(); ++i) {
-    out[i] = Entity{registry, entities[i]};
-  }
-}*/
-
 EntityFactory::Entity EntityFactory::createMinimal(EntityManager& entities) {
   return entities.entity()
       .add<ecs::benchmarks::base::components::PositionComponent>()
@@ -90,17 +59,6 @@ void EntityFactory::createMinimalBulk(EntityManager& registry, size_t nentities)
   desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
   ecs_bulk_init(registry, &desc);
 }
-
-/*void EntityFactory::createMinimalBulk(EntityManager& registry, std::vector<Entity>& out) {
-  ecs_bulk_desc_t desc{0};
-  desc.count = gsl::narrow_cast<int32_t>(out.size());
-  desc.ids[0] = registry.id<ecs::benchmarks::base::components::PositionComponent>();
-  desc.ids[1] = registry.id<ecs::benchmarks::base::components::VelocityComponent>();
-  const ecs_entity_t *entities = ecs_bulk_init(registry, &desc);
-  for (size_t i = 0; i < out.size(); ++i) {
-    out[i] = Entity{registry, entities[i]};
-  }
-}*/
 
 void EntityFactory::destroy(EntityManager& /*entities*/, Entity entity) {
   entity.destruct();

--- a/src/flecs/flecs/entities/EntityFactory.h
+++ b/src/flecs/flecs/entities/EntityFactory.h
@@ -16,19 +16,15 @@ public:
 
   static Entity createEmpty(EntityManager& entities);
   static void createEmptyBulk(EntityManager& registry, size_t nentities);
-  //static void createEmptyBulk(EntityManager& registry, std::vector<Entity>& out);
 
   static Entity createSingle(EntityManager& entities);
   static void createSingleBulk(EntityManager& registry, size_t nentities);
-  //static void createSingleBulk(EntityManager& registry, std::vector<Entity>& out);
 
   static Entity create(EntityManager& entities);
   static void createBulk(EntityManager& registry, size_t nentities);
-  //static void createBulk(EntityManager& registry, std::vector<Entity>& out);
 
   static Entity createMinimal(EntityManager& entities);
   static void createMinimalBulk(EntityManager& registry, size_t nentities);
-  //static void createMinimalBulk(EntityManager& registry, std::vector<Entity>& out);
 
   static void destroy(EntityManager& entities, Entity entity);
   static void destroyBulk(EntityManager& registry, std::vector<Entity>& entities);

--- a/src/flecs/flecs/entities/EntityFactory.h
+++ b/src/flecs/flecs/entities/EntityFactory.h
@@ -14,13 +14,24 @@ public:
   using EntityManager = ::flecs::world;
   using Entity = ::flecs::entity;
 
-  static Entity create(EntityManager& entities);
-  static Entity createSingle(EntityManager& entities);
-  static Entity createMinimal(EntityManager& entities);
   static Entity createEmpty(EntityManager& entities);
+  static void createEmptyBulk(EntityManager& registry, size_t nentities);
+  //static void createEmptyBulk(EntityManager& registry, std::vector<Entity>& out);
+
+  static Entity createSingle(EntityManager& entities);
+  static void createSingleBulk(EntityManager& registry, size_t nentities);
+  //static void createSingleBulk(EntityManager& registry, std::vector<Entity>& out);
+
+  static Entity create(EntityManager& entities);
+  static void createBulk(EntityManager& registry, size_t nentities);
+  //static void createBulk(EntityManager& registry, std::vector<Entity>& out);
+
+  static Entity createMinimal(EntityManager& entities);
+  static void createMinimalBulk(EntityManager& registry, size_t nentities);
+  //static void createMinimalBulk(EntityManager& registry, std::vector<Entity>& out);
 
   static void destroy(EntityManager& entities, Entity entity);
-
+  static void destroyBulk(EntityManager& registry, std::vector<Entity>& entities);
 
   [[nodiscard]] static inline const ecs::benchmarks::base::components::PositionComponent&
   getComponentOneConst(EntityManager& /*entities*/, Entity entity) {
@@ -44,7 +55,9 @@ public:
 
   [[nodiscard]] static inline ecs::benchmarks::base::components::DataComponent*
   getOptionalComponentThree(EntityManager& /*entities*/, Entity entity) {
-    return entity.get_mut<ecs::benchmarks::base::components::DataComponent>();
+    return entity.has<ecs::benchmarks::base::components::DataComponent>() 
+                ? entity.get_mut<ecs::benchmarks::base::components::DataComponent>()
+                : nullptr;
   }
 
 

--- a/src/flecs/flecs/systems/DataSystem.h
+++ b/src/flecs/flecs/systems/DataSystem.h
@@ -15,21 +15,23 @@ class DataSystem {
 public:
   using Entity = ::flecs::entity;
 
-  using TimeDelta = float;
-  inline static const auto update = [](::flecs::iter& it, size_t /*index*/,
-                                       ecs::benchmarks::base::components::DataComponent& data) {
+  using TimeDelta = double;
+  inline static const auto update = [](::flecs::iter& it,
+                                       ecs::benchmarks::base::components::DataComponent* data) {
     using DataComponent = ecs::benchmarks::base::components::DataComponent;
-    const TimeDelta dt = it.delta_time();
+    const auto dt = gsl::narrow_cast<TimeDelta>(it.delta_time());
 
-    data.dingy += 0.0001 * gsl::narrow_cast<double>(dt);
-    data.mingy = !data.mingy;
-    data.thingy++;
-    /// @FIXME(pico_ecs): SIGSEGV (Segmentation fault), can't copy string ... support for components with dynamic memory
-    /// (std::string) ?
-    // data.stringy = fmt::format(FMT_STRING("{:4.2f}"), data.dingy);
-    std::string stringy = fmt::format("{:4.2f}", data.dingy);
-    std::char_traits<char>::copy(gsl::span<char>(data.stringy).data(), gsl::span<const char>(stringy).data(),
-                                 std::min(stringy.length(), DataComponent::StringyMaxLength));
+    for (auto i : it) {
+      data[i].dingy += 0.0001 * dt;
+      data[i].mingy = !data[i].mingy;
+      data[i].thingy++;
+      /// @FIXME(pico_ecs): SIGSEGV (Segmentation fault), can't copy string ... support for components with dynamic memory
+      /// (std::string) ?
+      // data.stringy = fmt::format(FMT_STRING("{:4.2f}"), data[i].dingy);
+      std::string stringy = fmt::format(FMT_STRING("{:4.2f}"), data[i].dingy);
+      std::char_traits<char>::copy(data[i].stringy, stringy.data(),
+                                  std::min(stringy.length(), DataComponent::StringyMaxLength));
+    }
   };
 };
 

--- a/src/flecs/flecs/systems/MoreComplexSystem.h
+++ b/src/flecs/flecs/systems/MoreComplexSystem.h
@@ -19,10 +19,9 @@ public:
   }
 
   inline static const auto update = [](::flecs::iter& /*it*/, size_t /*index*/,
-                                       ecs::benchmarks::base::components::PositionComponent& position,
+                                       const ecs::benchmarks::base::components::PositionComponent& position,
                                        ecs::benchmarks::base::components::VelocityComponent& direction,
-                                       ecs::benchmarks::base::components::DataComponent& data) {
-    // const TimeDelta dt = it.delta_time();
+                                       const ecs::benchmarks::base::components::DataComponent& data) {
     if ((data.thingy % 10) == 0) {
       if (position.x > position.y) {
         direction.x = static_cast<float>(random(-5, 5));
@@ -45,8 +44,7 @@ public:
   using TimeDelta = float;
   using Entity = ::flecs::entity;
 
-  inline static const auto update = [](::flecs::iter& /*it*/, size_t /*index*/,
-                                       ecs::benchmarks::base::components::HealthComponent& health) {
+  inline static const auto update = [](ecs::benchmarks::base::components::HealthComponent& health) {
     using namespace ecs::benchmarks::base::components;
     if (health.hp <= 0) {
       health.hp = 0;
@@ -68,8 +66,7 @@ public:
   using TimeDelta = float;
   using Entity = ::flecs::entity;
 
-  inline static const auto update = [](::flecs::iter& /*it*/, size_t /*index*/,
-                                       ecs::benchmarks::base::components::HealthComponent& health,
+  inline static const auto update = [](ecs::benchmarks::base::components::HealthComponent& health,
                                        const ecs::benchmarks::base::components::DamageComponent& damage) {
     using namespace ecs::benchmarks::base::components;
     // Calculate damage

--- a/src/flecs/flecs/systems/MovementSystem.h
+++ b/src/flecs/flecs/systems/MovementSystem.h
@@ -13,12 +13,14 @@ public:
   using TimeDelta = double;
   using Entity = ::flecs::entity;
 
-  inline static const auto update = [](::flecs::iter& it, size_t /*index*/,
-                                       ecs::benchmarks::base::components::PositionComponent& position,
-                                       const ecs::benchmarks::base::components::VelocityComponent& direction) {
+  inline static const auto update = [](::flecs::iter& it,
+                                       ecs::benchmarks::base::components::PositionComponent* position,
+                                       const ecs::benchmarks::base::components::VelocityComponent* direction) {
     const auto dt = gsl::narrow_cast<TimeDelta>(it.delta_time());
-    position.x += direction.x * dt;
-    position.y += direction.y * dt;
+    for (auto i : it) {
+      position[i].x += direction[i].x * dt;
+      position[i].y += direction[i].y * dt;
+    }
   };
 };
 

--- a/src/oop/oop/entities/EntityFactory.cpp
+++ b/src/oop/oop/entities/EntityFactory.cpp
@@ -3,6 +3,7 @@
 #include "MovableDataObject.h"
 #include "MovableObject.h"
 #include <algorithm>
+#include <vector>
 
 namespace ecs::benchmarks::oop::entities {
 
@@ -69,7 +70,7 @@ void EntityFactory::createEmptyBulk(EntityManager& registry, std::vector<Entity>
 
 void EntityFactory::destroy(EntityManager& registry, Entity entity) {
   if (entity != nullptr && entity->id() > 0) {
-    registry[entity->id() - 1Z]->destroy();
+    registry[entity->id() - 1]->destroy();
   }
 }
 
@@ -81,7 +82,7 @@ void EntityFactory::destroyBulk(EntityManager& /*registry*/, std::vector<Entity>
 
 void EntityFactory::remove(EntityManager& registry, Entity entity) {
   if (entity != nullptr && entity->id() > 0) {
-    registry.erase(std::next(registry.begin(), entity->id() - 1Z));
+    registry.erase(std::next(registry.begin(), entity->id() - 1));
   }
 }
 

--- a/src/oop/oop/entities/MovableDataObject.cpp
+++ b/src/oop/oop/entities/MovableDataObject.cpp
@@ -13,6 +13,7 @@ void MovableDataObject::updatePosition(float dt) {
 }
 
 void MovableDataObject::update(float dt) {
+  using DataComponent = ecs::benchmarks::base::components::DataComponent;
   MovableObject::update(dt);
   // NOTE: copy-paste from DataSystem
   m_data.thingy++;
@@ -22,7 +23,8 @@ void MovableDataObject::update(float dt) {
   /// (std::string) ?
   // m_data.stringy = fmt::format(FMT_STRING("{:4.2f}"), m_data.dingy);
   std::string stringy = fmt::format(FMT_STRING("{:4.2f}"), m_data.dingy);
-  std::char_traits<char>::copy(m_data.stringy, stringy.data(), std::min(stringy.length(), m_data.StringyMaxLength));
+  std::char_traits<char>::copy(m_data.stringy, stringy.data(),
+                               std::min(stringy.length(), DataComponent::StringyMaxLength));
 }
 
 } // namespace ecs::benchmarks::oop::entities


### PR DESCRIPTION
Fixes a couple issues with how flecs is integrated with the benchmarks. Namely:
- Updated options used in `src/flecs/CMakeLists.txt`
- Disabled timers and other unneeded modules in `src/flecs/flecs/custom_flecs.h`
- Modified flecs systems to take advantage of `.iter(...)` to avoid needing to fetch `dt` for each individual entity. Also reduced the number of arguments to the functions.
- Implemented bulk entity operations in `src/flecs/flecs/entities/EntityFactory.h` and enabled the benchmarks in `benchmark/benchmarks/flecs-entities/FlecsEntityBenchmarkSuite.cpp`
- Fixed a few cases where either incorrectly used `HasBulkFeature` instead of `HasBulkFeatureWithOutput` or was missing `HasBulkFeatureWithOutput`.
- Removed `std::span` usage from `src/flecs/flecs/systems/DataSystem.h` to match the implementation for other benchmarks.
- Fixed implementation of `getOptionalComponentThree` which previously was only calling `get_mut` which will add the component if it doesn't exist.
- Removed C++23 feature usage. Fixes https://github.com/abeimler/ecs_benchmark/issues/14